### PR TITLE
PKGBUILD: vim with clipboard support

### DIFF
--- a/x86_64/vim-git/PKGBUILD
+++ b/x86_64/vim-git/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Antoine Stevan
+pkgname=vim-git
+pkgver=r16498.e1f3fd1d0
+pkgrel=1
+epoch=
+pkgdesc="My personal build of vim with clipboard support."
+arch=(x86_64)
+host="github.com"
+user="vim"
+repo="vim"
+url="https://$host/$user/$repo.git"
+license=()
+groups=()
+depends=(libxt)
+makedepends=(git)
+checkdepends=()
+optdepends=()
+provides=(vim)
+conflicts=(vim vim-git)
+replaces=()
+backup=()
+options=()
+install=
+changelog=
+source=("git+$url")
+noextract=()
+md5sums=('SKIP')
+validpgpkeys=()
+
+pkgver() {
+    cd "${_pkgname}"
+    printf "r%s.%s" "$(git -C "$repo" rev-list --count HEAD)" "$(git -C "$repo" rev-parse --short HEAD)"
+}
+
+build() {
+    cd "$repo"
+    make
+}
+
+package() {
+    cd "$repo"
+    sudo make install
+}


### PR DESCRIPTION
This PR adds a simple `PKGBUILD` for `vim` with system clipboard support.