### PR TITLE
FEATURE: install the vim binary inside /usr/bin/

### DIFF
--- a/x86_64/vim-git/PKGBUILD
+++ b/x86_64/vim-git/PKGBUILD
@@ -39,5 +39,5 @@ build() {
 
 package() {
     cd "$repo"
-    sudo make install
+    sudo make BINDIR=/usr/bin/ install
 }


### PR DESCRIPTION
This PR changes the install location of the final `vim` binary to `/usr/bin/`.