### PR TITLE
bump up versions

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,43 +1,44 @@
 ## The packages and their versions
-| package                      | version           |
+| name                         | version           |
 | ---------------------------- | ----------------- |
-| [amtoine-applications-git]   | 1.0.r2.277ee33    |
-| [amtoine-dmenu-git]          | 5.0.r589.8c0f76a  |
+| [amtoine-applications-git]   | 1.0.r6.27242df    |
+| [amtoine-dmenu-git]          | r597.28fb3e2      |
 | [amtoine-dwm-git]            | 5.0.r.            |
-| [amtoine-icons-git]          | 5.0.r4.f601c5e    |
-| [amtoine-scripts-git]        | 5.0.r3.9f46703    |
+| [amtoine-icons-git]          | r21.7cc7ce2       |
+| [amtoine-scripts-git]        | r34.64521f4       |
 | [amtoine-slock-git]          | 5.0.r132.a4d249a  |
-| [amtoine-sounds-git]         | 5.0.r3.9f46703    |
+| [amtoine-sounds-git]         | r4.5d10643        |
 | [amtoine-st-git]             | 5.0.r1176.8ceca6f |
 | [amtoine-surf-git]           | 5.0.r628.7e63f07  |
 | [amtoine-tabbed-git]         | 5.0.r628.7e63f07  |
-| [amtoine-wallpapers-git]     | 5.0.r589.8c0f76a  |
+| [amtoine-wallpapers-git]     | r32.e5ba1e1       |
 | [aura]                       | 3.2.9             |
 | [junnunkarim-wallpapers-git] | r4.9893042        |
-| [mut-ex-wallpapers-git]      | 5.0.r589.8c0f76a  |
+| [mut-ex-wallpapers-git]      | r36.849587d       |
 | [paru]                       | 1.10.0            |
 | [sfm-git]                    | 5.0.r589.8c0f76a  |
-| [syndrizzle-wallpapers-git]  | r10.a8c6e4de7     |
-| [vim-git]                    | r16498.e1f3fd1d0  |
+| [syndrizzle-wallpapers-git]  | r2.45953f1d2      |
+| [vim-git]                    | r16761.12167d8b8  |
 | [yay]                        | 11.2.0            |
 
 
-[amtoine-applications-git]:   https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-applications-git/PKGBUILD
-[amtoine-dmenu-git]:          https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-dmenu-git/PKGBUILD
-[amtoine-dwm-git]:            https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-dwm-git/PKGBUILD
-[amtoine-icons-git]:          https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-icons-git/PKGBUILD
-[amtoine-scripts-git]:        https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-scripts-git/PKGBUILD
-[amtoine-slock-git]:          https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-slock-git/PKGBUILD
-[amtoine-sounds-git]:         https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-sounds-git/PKGBUILD
-[amtoine-st-git]:             https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-st-git/PKGBUILD
-[amtoine-surf-git]:           https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-surf-git/PKGBUILD
-[amtoine-tabbed-git]:         https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-tabbed-git/PKGBUILD
-[amtoine-wallpapers-git]:     https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-wallpapers-git/PKGBUILD
-[aura]:                       https://github.com/amtoine/pkgbuilds/blob/main/x86_64/aura/PKGBUILD
+[amtoine-applications-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-applications-git/PKGBUILD
+[amtoine-dmenu-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-dmenu-git/PKGBUILD
+[amtoine-dwm-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-dwm-git/PKGBUILD
+[amtoine-icons-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-icons-git/PKGBUILD
+[amtoine-scripts-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-scripts-git/PKGBUILD
+[amtoine-slock-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-slock-git/PKGBUILD
+[amtoine-sounds-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-sounds-git/PKGBUILD
+[amtoine-st-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-st-git/PKGBUILD
+[amtoine-surf-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-surf-git/PKGBUILD
+[amtoine-tabbed-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-tabbed-git/PKGBUILD
+[amtoine-wallpapers-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/amtoine-wallpapers-git/PKGBUILD
+[aura]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/aura/PKGBUILD
 [junnunkarim-wallpapers-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/junnunkarim-wallpapers-git/PKGBUILD
-[mut-ex-wallpapers-git]:      https://github.com/amtoine/pkgbuilds/blob/main/x86_64/mut-ex-wallpapers-git/PKGBUILD
-[paru]:                       https://github.com/amtoine/pkgbuilds/blob/main/x86_64/paru/PKGBUILD
-[sfm-git]:                    https://github.com/amtoine/pkgbuilds/blob/main/x86_64/sfm-git/PKGBUILD
-[syndrizzle-wallpapers-git]:  https://github.com/amtoine/pkgbuilds/blob/main/x86_64/syndrizzle-wallpapers-git/PKGBUILD
-[vim-git]:                    https://github.com/amtoine/pkgbuilds/blob/main/x86_64/vim-git/PKGBUILD
-[yay]:                        https://github.com/amtoine/pkgbuilds/blob/main/x86_64/yay/PKGBUILD
+[mut-ex-wallpapers-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/mut-ex-wallpapers-git/PKGBUILD
+[paru]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/paru/PKGBUILD
+[sfm-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/sfm-git/PKGBUILD
+[syndrizzle-wallpapers-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/syndrizzle-wallpapers-git/PKGBUILD
+[vim-git]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/vim-git/PKGBUILD
+[yay]: https://github.com/amtoine/pkgbuilds/blob/main/x86_64/yay/PKGBUILD
+

--- a/generate-versions.nu
+++ b/generate-versions.nu
@@ -1,0 +1,44 @@
+#! /usr/bin/env nu
+
+let path = "x86_64"
+let  versions_file = "VERSIONS.md"
+
+let header = "## The packages and their versions"
+
+
+def gen-table [] {
+    grep "pkgver=" -r $path |
+        lines |
+        str replace $"($path)/" "[" |
+        str replace "/PKGBUILD" "]" |
+        split column ":pkgver=" |
+        rename name version |
+        sort-by name |
+        to md --pretty |
+        save --append $versions_file
+}
+
+
+def gen-links [] {
+    ls $path |
+        insert url {
+            |it|
+            let pkg = ($it.name  | str replace $"($path)/" "")
+            $"[($pkg)]: https://github.com/amtoine/pkgbuilds/blob/main/($path)/($pkg)/PKGBUILD"
+        } |
+        select url |
+        to csv -n |
+        save --append $versions_file
+}
+
+
+def main [] {
+    echo $header | save $versions_file
+    gen-table
+    echo "" | save --append $versions_file
+    echo "" | save --append $versions_file
+    gen-links
+}
+
+
+main

--- a/x86_64/amtoine-applications-git/PKGBUILD
+++ b/x86_64/amtoine-applications-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=amtoine-applications-git
-pkgver=1.0.r2.277ee33
+pkgver=1.0.r6.27242df
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of .desktop files, a.k.a. linux applications."

--- a/x86_64/amtoine-dmenu-git/PKGBUILD
+++ b/x86_64/amtoine-dmenu-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=amtoine-dmenu-git
-pkgver=5.0.r589.8c0f76a
+pkgver=r597.28fb3e2
 pkgrel=1
 epoch=
 pkgdesc="A heavily patched build of dmenu."

--- a/x86_64/amtoine-icons-git/PKGBUILD
+++ b/x86_64/amtoine-icons-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=amtoine-icons-git
-pkgver=5.0.r4.f601c5e
+pkgver=r21.7cc7ce2
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of icons."

--- a/x86_64/amtoine-scripts-git/PKGBUILD
+++ b/x86_64/amtoine-scripts-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=amtoine-scripts-git
-pkgver=5.0.r3.9f46703
+pkgver=r34.64521f4
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of scripts."

--- a/x86_64/amtoine-sounds-git/PKGBUILD
+++ b/x86_64/amtoine-sounds-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=amtoine-sounds-git
-pkgver=5.0.r3.9f46703
+pkgver=r4.5d10643
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of sounds."

--- a/x86_64/amtoine-wallpapers-git/PKGBUILD
+++ b/x86_64/amtoine-wallpapers-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=amtoine-wallpapers-git
-pkgver=5.0.r589.8c0f76a
+pkgver=r32.e5ba1e1
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of wallpapers."

--- a/x86_64/mut-ex-wallpapers-git/PKGBUILD
+++ b/x86_64/mut-ex-wallpapers-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: mut-ex
 pkgname=mut-ex-wallpapers-git
-pkgver=5.0.r589.8c0f76a
+pkgver=r36.849587d
 pkgrel=1
 epoch=
 pkgdesc="Public collection of wallpapers."

--- a/x86_64/syndrizzle-wallpapers-git/PKGBUILD
+++ b/x86_64/syndrizzle-wallpapers-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=syndrizzle-wallpapers-git
-pkgver=r10.a8c6e4de7
+pkgver=r2.45953f1d2
 pkgrel=1
 epoch=
 pkgdesc="A collection of personal configuration files for various rices I have made (quote from Syndrizzle/hotfiles)."

--- a/x86_64/vim-git/PKGBUILD
+++ b/x86_64/vim-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=vim-git
-pkgver=r16498.e1f3fd1d0
+pkgver=r16761.12167d8b8
 pkgrel=1
 epoch=
 pkgdesc="My personal build of vim with clipboard support."


### PR DESCRIPTION
This PR bumps up the versions of the packages and adds a simple script to generate `VERSIONS.md` automatically with `nushell`.