### PR TITLE
UPDATE: bump the versions of the packages

### DIFF
--- a/x86_64/goat-applications-git/PKGBUILD
+++ b/x86_64/goat-applications-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=goat-applications-git
-pkgver=1.0.r6.27242df
+pkgver=r7.14bb72a
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of .desktop files, a.k.a. linux applications."
@@ -29,7 +29,7 @@ validpgpkeys=()
 
 pkgver() {
     cd "${_pkgname}"
-    printf "1.0.r%s.%s" "$(git -C "$repo" rev-list --count HEAD)" "$(git -C "$repo" rev-parse --short HEAD)"
+    printf "r%s.%s" "$(git -C "$repo" rev-list --count HEAD)" "$(git -C "$repo" rev-parse --short HEAD)"
 }
 
 package() {

--- a/x86_64/goat-icons-git/PKGBUILD
+++ b/x86_64/goat-icons-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=goat-icons-git
-pkgver=r21.7cc7ce2
+pkgver=r22.a2864f9
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of icons."

--- a/x86_64/goat-junnunkarim-wallpapers-git/PKGBUILD
+++ b/x86_64/goat-junnunkarim-wallpapers-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=goat-junnunkarim-wallpapers-git
-pkgver=r4.9893042
+pkgver=r5.ed614bd
 pkgrel=1
 epoch=
 pkgdesc="A collection of wallpapers from junnunkarim/dotfiles-linux."

--- a/x86_64/goat-scripts-git/PKGBUILD
+++ b/x86_64/goat-scripts-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=goat-scripts-git
-pkgver=r34.64521f4
+pkgver=r41.70ca3a3
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of scripts."

--- a/x86_64/goat-sounds-git/PKGBUILD
+++ b/x86_64/goat-sounds-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=goat-sounds-git
-pkgver=r4.5d10643
+pkgver=r5.0f05e4f
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of sounds."

--- a/x86_64/goat-wallpapers-git/PKGBUILD
+++ b/x86_64/goat-wallpapers-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=goat-wallpapers-git
-pkgver=r32.e5ba1e1
+pkgver=r33.52e7e25
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of wallpapers."


### PR DESCRIPTION
This PR bumps the versions of the mainly used packages:
- `goat-applications-git` -> `r7.14bb72a`
- `goat-icons-git` -> `r22.a2864f9`
- `goat-junnunkarim-wallpapers-git` -> `r5.ed614bd`
- `goat-scripts-git` -> `r41.70ca3a3`
- `goat-sounds-git` -> `r5.0f05e4f`
- `goat-wallpapers-git` -> `r33.52e7e25`

Also removes the extra `1.0.` in front of the version of the applications :+1: 