### PR TITLE
UPDATE: bump up the version of `goat-application-git`

### DIFF
--- a/x86_64/goat-applications-git/PKGBUILD
+++ b/x86_64/goat-applications-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=goat-applications-git
-pkgver=r7.14bb72a
+pkgver=r8.25358fa
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of .desktop files, a.k.a. linux applications."


### PR DESCRIPTION
This PR bumps the version of `goat-application-git` from `r7.14bb72a` to `r8.25358fa`.