### PR TITLE
UPDATE: bump up `goat-applications-git`

### DIFF
--- a/x86_64/goat-applications-git/PKGBUILD
+++ b/x86_64/goat-applications-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Antoine Stevan
 pkgname=goat-applications-git
-pkgver=r8.25358fa
+pkgver=r9.e5ce6b0
 pkgrel=1
 epoch=
 pkgdesc="My personal collection of .desktop files, a.k.a. linux applications."


### PR DESCRIPTION
This PR bumps the version of `goat-applications-git` from `r8.25358fa` to `r9.e5ce6b0`.